### PR TITLE
Update qBittorrent API Call

### DIFF
--- a/qbtAPI.js
+++ b/qbtAPI.js
@@ -128,7 +128,7 @@ class QbtAPI {
         savepath: params.savepath,
         category: params.category || ""
       }
-      await this.call("POST", "/command/download", apiData)
+      await this.call("POST", "/api/v2/torrents/add", apiData)
     } else {
       // no URLs to download
       logger.info("No URLs to download.")


### PR DESCRIPTION
The API call for adding a torrent has changed as [officially documented](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)).